### PR TITLE
Fix: Pin ZMK and driver to v0.3 to fix build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,4 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3

--- a/config/west.yml
+++ b/config/west.yml
@@ -9,11 +9,11 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: badjeff
-      revision: main
+      revision: zmk-0.3
     # - name: zmk-pmw3610-driver
     #   remote: cyboard
     #   revision: startup_optimization


### PR DESCRIPTION
The current build fails when tracking main due to upstream changes and board collisions. This pins dependencies to known-working versions.

Changes:
- Workflow: Switched build-user-config.yml from @main to @v0.3.
- ZMK Core: Set zmk revision to v0.3.
- Sensor Driver: Pinned zmk-pmw3610-driver to the zmk-0.3 branch.

Built via GitHub Actions in my fork and verified on my device.